### PR TITLE
don't assign empty string if merged[css_att] is empty

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -76,8 +76,10 @@ class Premailer
           # Duplicate CSS attributes as HTML attributes
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name) && @options[:css_to_attributes]
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
-              new_html_att = merged[css_att].gsub(/url\(['|"](.*)['|"]\)/, '\1').gsub(/;$|\s*!important/, '').strip if el[html_att].nil? and not merged[css_att].empty?
-              css_att.end_with?('color') && @options[:rgb_to_hex_attributes] ? el[html_att] = ensure_hex(new_html_att) : el[html_att] = new_html_att
+              if el[html_att].nil? and not merged[css_att].empty?
+                new_html_att = merged[css_att].gsub(/url\(['|"](.*)['|"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
+                el[html_att] = css_att.end_with?('color') && @options[:rgb_to_hex_attributes] ? ensure_hex(new_html_att) : new_html_att
+              end
               merged.instance_variable_get("@declarations").tap do |declarations|
                 declarations.delete(css_att)
               end

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -310,7 +310,7 @@ END_HTML
     </body> </html>
     END_HTML
 
-    pm = Premailer.new(html, :with_html_string => true, :rgb_to_hex_attributes => true, :adapter => :nokogiri)
+    pm = Premailer.new(html, :with_html_string => true, :rgb_to_hex_attributes => true, :remove_scripts => true, :adapter => :nokogiri)
     pm.to_inline_css
     doc = pm.processed_doc
     assert_equal 'FAFAFA', doc.at('table')['bgcolor']

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -302,6 +302,21 @@ END_HTML
     end
   end
 
+  def test_empty_css_att
+    html = <<-END_HTML
+    <html> <head> <style>table { background-color: rgb(250, 250, 250); width: "550px"; } </style>
+    <body>
+    <table> <tr> <td> Test </td> </tr> </table>
+    </body> </html>
+    END_HTML
+
+    pm = Premailer.new(html, :with_html_string => true, :rgb_to_hex_attributes => true, :remove_scripts => true, :adapter => :nokogiri)
+    pm.to_inline_css
+    doc = pm.processed_doc
+
+    assert_equal '<table style="width: \'550px\';" bgcolor="FAFAFA"> <tr> <td> Test </td> </tr> </table>', doc.at('table').to_s
+  end
+
   def test_rgb_color
     html = <<-END_HTML
     <html> <head> <style>table { background-color: rgb(250, 250, 250); } </style>


### PR DESCRIPTION
PROD-1131 #close
- Previously when merged[css_att].empty? the assignent to el[html_att] did not happen
- [893e37e] assigns an empty variable and eventually an empty string to the `el`, this was screwing up nokogiri
- Fix by wrapping ensure_hex in the assignments logic (not merged[css_att].empty?)
