### PR TITLE
Add compatibility between rgba blending and preserve style attribute

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -78,7 +78,11 @@ class Premailer
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
               if el[html_att].nil? and not merged[css_att].empty?
                 new_html_att = merged[css_att].gsub(/url\(['"](.*)['"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
-                el[html_att] = css_att.end_with?('color') && @options[:rgb_to_hex_attributes] ? ensure_hex(new_html_att, el) : new_html_att
+                if @options[:rgb_to_hex_attributes] && css_att.end_with?('color')
+                  new_html_att = ensure_hex(new_html_att, el)
+                end
+                el[html_att] = new_html_att
+                merged[css_att] = new_html_att.to_s
               end
               unless @options[:preserve_style_attribute]
                 merged.instance_variable_get("@declarations").tap do |declarations|

--- a/lib/premailer/adapter/nokogiri_fast.rb
+++ b/lib/premailer/adapter/nokogiri_fast.rb
@@ -80,7 +80,11 @@ class Premailer
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
               if el[html_att].nil? and not merged[css_att].empty?
                 new_html_att = merged[css_att].gsub(/url\(['"](.*)['"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
-                el[html_att] = css_att.end_with?('color') && @options[:rgb_to_hex_attributes] ? ensure_hex(new_html_att, el) : new_html_att
+                if @options[:rgb_to_hex_attributes] && css_att.end_with?('color')
+                  new_html_att = ensure_hex(new_html_att, el)
+                end
+                el[html_att] = new_html_att
+                merged[css_att] = new_html_att.to_s
               end
               unless @options[:preserve_style_attribute]
                 merged.instance_variable_get("@declarations").tap do |declarations|

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -78,7 +78,11 @@ class Premailer
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
               if el[html_att].nil? and not merged[css_att].empty?
                 new_html_att = merged[css_att].gsub(/url\(['"](.*)['"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
-                el[html_att] = css_att.end_with?('color') && @options[:rgb_to_hex_attributes] ? ensure_hex(new_html_att, el) : new_html_att
+                if @options[:rgb_to_hex_attributes] && css_att.end_with?('color')
+                  new_html_att = ensure_hex(new_html_att, el)
+                end
+                el[html_att] = new_html_att
+                merged[css_att] = new_html_att.to_s
               end
               unless @options[:preserve_style_attribute]
                 merged.instance_variable_get("@declarations").tap do |declarations|

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -293,6 +293,21 @@ END_HTML
     assert_equal '#FAFAFA', doc.at('table')['bgcolor']
   end
 
+  def test_rgb_color_with_preserve_style
+    html = <<-END_HTML
+    <html> <head> <style>table { background-color: rgb(250, 250, 250); } </style>
+    <body>
+    <table> <tr> <td> Test </td> </tr> </table>
+    </body> </html>
+    END_HTML
+
+    pm = Premailer.new(html, :with_html_string => true, :preserve_style_attribute => true, :rgb_to_hex_attributes => true, :remove_scripts => true, :adapter => :nokogiri)
+    pm.to_inline_css
+    doc = pm.processed_doc
+    assert_equal '#FAFAFA', doc.at('table')['bgcolor']
+    assert_equal 'background-color: #FAFAFA;', doc.at('table')['style']
+  end
+
   def test_non_rgb_color
     html = <<-END_HTML
     <html> <head> <style>table { background-color:red; } </style>


### PR DESCRIPTION
If both the preserve style attribute and the rgba blending options are
enabled, there is a discrepancy between the style and the element
attribute because the style uses the original value instead of the
blended one.
This fix ensures that style and element attribute are outputted with the
same value.